### PR TITLE
NFCタグから読み取ったTextをAPIに送信するよう変更

### DIFF
--- a/toda-nfc-reader/NFCReader.swift
+++ b/toda-nfc-reader/NFCReader.swift
@@ -9,7 +9,7 @@ import CoreNFC
 
 final class NFCReader: NSObject {
 
-    var completionHandler: (() -> Void)?
+    var completionHandler: ((String) -> Void)?
 
     enum State {
         case standBy
@@ -206,7 +206,9 @@ extension NFCReader: NFCNDEFReaderSessionDelegate {
                         self.stopSession(error: "このNFCタグは対応していません。")
                         return
                     }
-                    self.completionHandler?()
+
+                    guard let tagTextInfomation = message.records.first(where: { String(data: $0.type, encoding: .utf8) == "T" })?.wellKnownTypeTextPayload().0 else { return }
+                    self.completionHandler?(tagTextInfomation)
                 }
 
             default:

--- a/toda-nfc-reader/Screen/Main/UIKit/MainViewController.swift
+++ b/toda-nfc-reader/Screen/Main/UIKit/MainViewController.swift
@@ -39,8 +39,8 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        nfcReader.completionHandler = { [weak self] in
-            self?.fetch()
+        nfcReader.completionHandler = { [weak self] query in
+            self?.fetch(query: query)
         }
     }
 
@@ -61,8 +61,8 @@ final class MainViewController: UIViewController {
         fetch()
     }
 
-    private func fetch() {
-        APIClient.fetch(query: "test") { [weak self] result in
+    private func fetch(query: String = "test") {
+        APIClient.fetch(query: query) { [weak self] result in
             switch result {
             case .success(let response):
 


### PR DESCRIPTION
__\*は必須入力__

## 1. マージ期限
今週中

## 2-B. 既存機能修正
- NFCTagのtextメッセージを取得し、それをクロージャーでViewControllerに渡して、APIを叩くよう変更

--------------------------------------
## 3. 影響範囲
- NFCTag読み取り
- MainView

--------------------------------------
## 6. Checklist

- [x] 実機で読み取り後にAPI送信ができていること